### PR TITLE
Fix orphaned Apache vhosts and the 502 they cause (#17)

### DIFF
--- a/scripts/system/add_domain.sh
+++ b/scripts/system/add_domain.sh
@@ -210,7 +210,15 @@ VHOST
 
 # (Port was already reserved in ports_domains.conf during atomic allocation above.)
 a2ensite "${DOMAIN}.conf" > /dev/null 2>&1
-systemctl reload apache2
+# Validate before reloading — a bad vhost here must not be able to knock the
+# whole server over the next time Apache is restarted (e.g. by apt upgrade).
+if apache2ctl configtest 2>&1 | grep -q "Syntax OK"; then
+    systemctl reload apache2
+else
+    echo -e "${RED}Apache config is invalid — disabling '${DOMAIN}' and NOT reloading.${NC}"
+    apache2ctl configtest 2>&1 | sed 's/^/    /'
+    a2dissite "${DOMAIN}.conf" > /dev/null 2>&1
+fi
 
 # ----------------------------------------------------------------
 # MariaDB — grant user privileges on username_* databases
@@ -223,7 +231,10 @@ MYSQL
 # ----------------------------------------------------------------
 # Welcome index page
 # ----------------------------------------------------------------
-if [ -f "$WELCOME_TEMPLATE" ]; then
+# Only ever drop the placeholder into an empty web root. This script also runs
+# in "recreate" mode on an existing domain (see the vhost cleanup near the top),
+# and overwriting a live site's index.php there is data loss.
+if [ -f "$WELCOME_TEMPLATE" ] && [ -z "$(ls -A "$DOC_ROOT" 2>/dev/null)" ]; then
     cp "$WELCOME_TEMPLATE" "$DOC_ROOT/index.php"
     sed -i "s|{{DOMAIN}}|$DOMAIN|g"     "$DOC_ROOT/index.php"
     sed -i "s|{{PORT}}|$PORT|g"         "$DOC_ROOT/index.php"

--- a/scripts/system/delete_account.sh
+++ b/scripts/system/delete_account.sh
@@ -64,17 +64,45 @@ if ! id "$USERNAME" &>/dev/null; then
     exit 1
 fi
 
-# Find all domains for this user
+# Find all domains for this user.
+# The home directory alone is not authoritative — if it was already removed (a
+# partial delete, a manual rm, or delete_user.sh --force) the glob finds nothing,
+# remove_domain.sh never runs, and the Apache vhost survives pointing at a
+# DocumentRoot and ErrorLog dir that no longer exist. Apache then refuses to
+# start on the *next* restart, taking every site on the box down. So take the
+# union of the filesystem, the panel DB, and the vhosts owned by this user.
 DOMAINS=()
+add_domain_once() {
+    local d="$1"
+    [ -z "$d" ] && return
+    [ "$d" = "tmp" ] && return
+    local existing
+    for existing in "${DOMAINS[@]}"; do
+        [ "$existing" = "$d" ] && return
+    done
+    DOMAINS+=("$d")
+}
+
 if [ -d "/home/$USERNAME" ]; then
     for dir in /home/$USERNAME/*/www; do
         [ -d "$dir" ] || continue
-        D=$(basename "$(dirname "$dir")")
-        # Skip tmp and other non-domain dirs
-        [ "$D" = "tmp" ] && continue
-        DOMAINS+=("$D")
+        add_domain_once "$(basename "$(dirname "$dir")")"
     done
 fi
+
+if [ -f "$PANEL_DB" ]; then
+    while read -r D; do
+        add_domain_once "$D"
+    done < <(sqlite3 "$PANEL_DB" "SELECT d.domain_name FROM domains d JOIN hosting_users h ON d.hosting_user_id = h.id WHERE h.username = '${USERNAME}'" 2>/dev/null)
+fi
+
+for conf in /etc/apache2/sites-available/*.conf; do
+    [ -f "$conf" ] || continue
+    DOC_ROOT=$(grep -oP 'DocumentRoot\s+\K\S+' "$conf" 2>/dev/null | head -1)
+    case "$DOC_ROOT" in
+        /home/"$USERNAME"/*) add_domain_once "$(basename "$conf" .conf)" ;;
+    esac
+done
 
 echo -e "  User:    ${BOLD}$USERNAME${NC}"
 echo -e "  Domains: ${BOLD}${#DOMAINS[@]}${NC}"

--- a/scripts/system/dns_check.sh
+++ b/scripts/system/dns_check.sh
@@ -16,11 +16,13 @@ PANEL_DB="/var/www/inetpanel/db/inetpanel.db"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --domain) DOMAIN="$2"; shift 2 ;;
-        *) shift ;;
+        -*)       shift ;;
+        # Accept a bare domain too: `inetp dns_check example.com`
+        *)        [ -z "$DOMAIN" ] && DOMAIN="$1"; shift ;;
     esac
 done
 
-[ -z "$DOMAIN" ] && { echo -e "${RED}Domain is required (--domain).${NC}"; exit 1; }
+[ -z "$DOMAIN" ] && { echo -e "${RED}Domain is required.${NC}  Usage: inetp dns_check <domain>"; exit 1; }
 
 PASS=0; FAIL=0
 

--- a/scripts/system/inetp
+++ b/scripts/system/inetp
@@ -112,6 +112,7 @@ case "$COMMAND" in
     ssl_manage)        bash "$SCRIPTS_DIR/ssl_manage.sh"       "$@" ;;
     fix_permissions)   bash "$SCRIPTS_DIR/fix_permissions.sh"   "$@" ;;
     rebuild_pools)     bash "$SCRIPTS_DIR/rebuild_pools.sh"     "$@" ;;
+    rebuild_vhosts)    bash "$SCRIPTS_DIR/rebuild_vhosts.sh"    "$@" ;;
     multiphp_manage)   bash "$SCRIPTS_DIR/multiphp_manage.sh"   "$@" ;;
     panel_ssl)         bash "$SCRIPTS_DIR/panel_ssl.sh"         "$@" ;;
     service_monitor)   bash "$SCRIPTS_DIR/service_monitor.sh"   "$@" ;;
@@ -196,6 +197,7 @@ case "$COMMAND" in
         echo -e "    ${GREEN}firewall${NC}          Firewall management (status, flush, ban, unban)"
         echo -e "    ${GREEN}fix_permissions${NC}   Reset file/directory permissions for a user"
         echo -e "    ${GREEN}rebuild_pools${NC}    Regenerate missing PHP-FPM pool configs"
+        echo -e "    ${GREEN}rebuild_vhosts${NC}   Regenerate missing Apache vhosts, flag orphaned ones"
         echo -e "    ${GREEN}ssl_manage${NC}        SSL certificate management (issue, revoke, renew, status)"
         echo -e "    ${GREEN}list${NC}              List all active accounts and ports"
         echo ""

--- a/scripts/system/rebuild_vhosts.sh
+++ b/scripts/system/rebuild_vhosts.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+# ==============================================================================
+# rebuild_vhosts.sh — Regenerate missing Apache vhosts and flag broken ones
+# Usage: inetp rebuild_vhosts [--check] [--disable-orphans]
+#
+# Two jobs, both driven by the panel database:
+#
+#   1. MISSING  — a domain the panel knows about that has no vhost in
+#                 sites-available. The site's files and FPM pool are fine, but
+#                 Apache has no idea it exists, so it 404s or falls through to
+#                 another vhost. Regenerated from the same template add_domain.sh
+#                 uses. Existing vhosts are never touched.
+#
+#   2. ORPHANED — an *enabled* vhost whose DocumentRoot or ErrorLog directory no
+#                 longer exists, usually left behind by an interrupted delete.
+#                 Apache keeps serving on its already-loaded config, so nothing
+#                 looks wrong until the next full restart (an apt upgrade, a
+#                 reboot) — at which point Apache refuses to start and *every*
+#                 site on the box goes down. Reported by default; pass
+#                 --disable-orphans to a2dissite them.
+#
+# Nothing is reloaded unless `apache2ctl configtest` passes.
+# ==============================================================================
+
+PANEL_DB="/var/www/inetpanel/db/inetpanel.db"
+CUSTOM_PORTS_CONF="/etc/apache2/ports_domains.conf"
+
+if [ -t 1 ]; then
+    BOLD='\033[1m'; GREEN='\033[1;32m'; RED='\033[1;31m'; YELLOW='\033[1;33m'; CYAN='\033[1;36m'; DIM='\033[2m'; NC='\033[0m'
+else
+    BOLD=''; GREEN=''; RED=''; YELLOW=''; CYAN=''; DIM=''; NC=''
+fi
+
+CHECK_ONLY=0
+DISABLE_ORPHANS=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --check)            CHECK_ONLY=1; shift ;;
+        --disable-orphans)  DISABLE_ORPHANS=1; shift ;;
+        *) shift ;;
+    esac
+done
+
+[ ! -f "$PANEL_DB" ] && { echo -e "${RED}Panel database not found: ${PANEL_DB}${NC}"; exit 1; }
+
+DEFAULT_PHP=$(sqlite3 "$PANEL_DB" "SELECT value FROM settings WHERE key='php_default_version'" 2>/dev/null)
+DEFAULT_PHP=${DEFAULT_PHP:-8.4}
+
+echo -e "${BOLD}Rebuilding Apache VHosts${NC}"
+echo ""
+
+CREATED=0; SKIPPED=0; ERRORS=0; ORPHANS=0; CHANGED=0
+
+# ── 1. Missing vhosts ─────────────────────────────────────────────────────────
+echo -e "${CYAN}▸ Missing vhosts${NC}"
+
+while IFS="|" read -r DOMAIN USERNAME DOC_ROOT PHP_VER PORT; do
+    [ -z "$DOMAIN" ] && continue
+    VHOST_CONF="/etc/apache2/sites-available/${DOMAIN}.conf"
+
+    if [ -f "$VHOST_CONF" ]; then
+        SKIPPED=$((SKIPPED + 1))
+        continue
+    fi
+
+    if ! id "$USERNAME" &>/dev/null; then
+        echo -e "  ${RED}ERROR${NC}   ${DOMAIN} — system user '${USERNAME}' does not exist"
+        ERRORS=$((ERRORS + 1))
+        continue
+    fi
+
+    [ -z "$DOC_ROOT" ] && DOC_ROOT="/home/${USERNAME}/${DOMAIN}/www"
+    LOG_DIR="/home/${USERNAME}/${DOMAIN}/logs"
+
+    # Port: prefer domains.port, fall back to account_ports, then auto-assign.
+    if [ -z "$PORT" ] || [ "$PORT" = "0" ]; then
+        PORT=$(sqlite3 "$PANEL_DB" "SELECT port FROM account_ports WHERE domain_name = '${DOMAIN}'" 2>/dev/null)
+    fi
+    if [ -z "$PORT" ]; then
+        USED=$( { grep -hoE '^Listen[[:space:]]+[0-9]+' "$CUSTOM_PORTS_CONF" 2>/dev/null | awk '{print $2}'
+                  grep -rhoE '<VirtualHost \*:[0-9]+>' /etc/apache2/sites-available/ 2>/dev/null | grep -oE '[0-9]+'
+                  printf '%s\n' 80 443 1443 8443 8888; } | sort -un )
+        PORT=1080
+        while printf '%s\n' "$USED" | grep -qx "$PORT"; do PORT=$((PORT + 1)); done
+        echo -e "  ${DIM}${DOMAIN} — no port on record, assigning ${PORT}${NC}"
+    fi
+
+    if [ "$CHECK_ONLY" -eq 1 ]; then
+        echo -e "  ${YELLOW}MISSING${NC} ${DOMAIN} (${USERNAME}, port ${PORT})"
+        CREATED=$((CREATED + 1))
+        continue
+    fi
+
+    POOL_NAME="${USERNAME}_$(echo "$DOMAIN" | tr '.-' '_')"
+    FPM_SOCK="/run/php/php${PHP_VER}-fpm-${POOL_NAME}.sock"
+    SSL_CERT="/etc/letsencrypt/live/${DOMAIN}/fullchain.pem"
+    SSL_KEY="/etc/letsencrypt/live/${DOMAIN}/privkey.pem"
+
+    if [ ! -f "$SSL_CERT" ]; then
+        echo -e "  ${RED}ERROR${NC}   ${DOMAIN} — no certificate at ${SSL_CERT}"
+        echo -e "          ${DIM}issue one first: inetp ssl_manage issue ${DOMAIN} --self-signed${NC}"
+        ERRORS=$((ERRORS + 1))
+        continue
+    fi
+
+    mkdir -p "$DOC_ROOT" "$LOG_DIR"
+    chown "${USERNAME}:www-data" "$DOC_ROOT" "$LOG_DIR" 2>/dev/null
+
+    # ServerAlias www. only for apex domains — matches add_domain.sh / CF tunnel logic
+    DOT_COUNT=$(echo "$DOMAIN" | tr -cd '.' | wc -c)
+    if [ "$DOT_COUNT" -eq 1 ] && [[ "$DOMAIN" != www.* ]]; then
+        SERVER_ALIAS="    ServerAlias www.${DOMAIN}"
+    else
+        SERVER_ALIAS=""
+    fi
+
+    cat << VHOST > "$VHOST_CONF"
+<VirtualHost *:${PORT}>
+    ServerAdmin webmaster@${DOMAIN}
+    ServerName  ${DOMAIN}
+${SERVER_ALIAS}
+    DocumentRoot ${DOC_ROOT}
+
+    SSLEngine on
+    SSLCertificateFile    ${SSL_CERT}
+    SSLCertificateKeyFile ${SSL_KEY}
+
+    # Redirect plain HTTP requests to HTTPS (when someone hits the port without TLS)
+    ErrorDocument 400 "<!DOCTYPE html><html><head><script>location.replace(location.href.replace('http:','https:'))</script></head><body>Redirecting to HTTPS...</body></html>"
+
+    <FilesMatch "\.php\$">
+        SetHandler "proxy:unix:${FPM_SOCK}|fcgi://localhost"
+    </FilesMatch>
+
+    <Directory ${DOC_ROOT}>
+        Options Indexes FollowSymLinks
+        AllowOverride All
+        Require all granted
+        LimitRequestBody 104857600
+    </Directory>
+
+    ErrorLog  ${LOG_DIR}/apache_error.log
+    CustomLog ${LOG_DIR}/apache_access.log combined
+</VirtualHost>
+VHOST
+
+    grep -qx "Listen ${PORT}" "$CUSTOM_PORTS_CONF" 2>/dev/null || echo "Listen ${PORT}" >> "$CUSTOM_PORTS_CONF"
+    a2ensite "${DOMAIN}.conf" > /dev/null 2>&1
+
+    echo -e "  ${GREEN}CREATED${NC} ${DOMAIN} → ${VHOST_CONF} (port ${PORT})"
+    CREATED=$((CREATED + 1))
+    CHANGED=1
+done < <(sqlite3 "$PANEL_DB" "SELECT d.domain_name, h.username, d.document_root,
+             COALESCE(NULLIF(d.php_version,'inherit'), '$DEFAULT_PHP'), d.port
+         FROM domains d JOIN hosting_users h ON d.hosting_user_id = h.id" 2>/dev/null)
+
+[ "$CREATED" -eq 0 ] && echo -e "  ${DIM}None — all ${SKIPPED} domain(s) have a vhost.${NC}"
+echo ""
+
+# ── 2. Orphaned vhosts ────────────────────────────────────────────────────────
+echo -e "${CYAN}▸ Orphaned vhosts${NC}"
+
+for conf in /etc/apache2/sites-enabled/*.conf; do
+    [ -e "$conf" ] || continue
+    NAME=$(basename "$conf")
+    DOC=$(grep -oP 'DocumentRoot\s+\K\S+' "$conf" 2>/dev/null | head -1)
+    ERR=$(grep -oP 'ErrorLog\s+\K\S+' "$conf" 2>/dev/null | head -1)
+
+    REASONS=""
+    # Skip paths built from Apache env vars (${APACHE_LOG_DIR} etc.) — not resolvable here.
+    case "$DOC" in *'${'*) DOC="" ;; esac
+    case "$ERR" in *'${'*) ERR="" ;; esac
+    [ -n "$DOC" ] && [ ! -d "$DOC" ] && REASONS="${REASONS}\n            DocumentRoot missing: ${DOC}"
+    [ -n "$ERR" ] && [ ! -d "$(dirname "$ERR")" ] && REASONS="${REASONS}\n            log dir missing:      $(dirname "$ERR")"
+
+    [ -z "$REASONS" ] && continue
+
+    ORPHANS=$((ORPHANS + 1))
+    echo -e "  ${RED}ORPHAN${NC}  ${NAME}${REASONS}"
+
+    if [ "$DISABLE_ORPHANS" -eq 1 ] && [ "$CHECK_ONLY" -eq 0 ]; then
+        a2dissite "$NAME" > /dev/null 2>&1
+        echo -e "          ${YELLOW}disabled${NC}"
+        CHANGED=1
+    fi
+done
+
+if [ "$ORPHANS" -eq 0 ]; then
+    echo -e "  ${DIM}None.${NC}"
+elif [ "$DISABLE_ORPHANS" -eq 0 ]; then
+    echo ""
+    echo -e "  ${YELLOW}A missing log directory is fatal at Apache startup. These will keep${NC}"
+    echo -e "  ${YELLOW}serving until something restarts Apache, then it will refuse to start${NC}"
+    echo -e "  ${YELLOW}and every site goes down. Re-run with --disable-orphans to clear them.${NC}"
+fi
+echo ""
+
+# ── Reload ────────────────────────────────────────────────────────────────────
+if [ "$CHECK_ONLY" -eq 1 ]; then
+    echo -e "${DIM}--check: nothing was modified.${NC}"
+elif [ "$CHANGED" -eq 1 ]; then
+    if apache2ctl configtest 2>&1 | grep -q "Syntax OK"; then
+        systemctl reload apache2 && echo -e "  ${GREEN}Reloaded apache2${NC}"
+    else
+        echo -e "${RED}Apache config is invalid — NOT reloading.${NC}"
+        apache2ctl configtest 2>&1 | sed 's/^/    /'
+        exit 1
+    fi
+fi
+
+echo ""
+echo -e "Created: ${BOLD}${CREATED}${NC}   Skipped: ${BOLD}${SKIPPED}${NC}   Orphaned: ${BOLD}${ORPHANS}${NC}   Errors: ${BOLD}${ERRORS}${NC}"

--- a/scripts/system/remove_domain.sh
+++ b/scripts/system/remove_domain.sh
@@ -57,7 +57,16 @@ if [ -f "$VHOST_CONF" ]; then
     if [ -n "$PORT" ]; then
         sed -i "/^Listen ${PORT}$/d" "$CUSTOM_PORTS_CONF"
     fi
-    systemctl reload apache2 || systemctl restart apache2
+    # Validate before touching Apache. Never escalate a failed reload into a
+    # restart: a reload that fails leaves the running (good) config serving,
+    # but a restart on a broken config takes every site on the box down.
+    if apache2ctl configtest 2>&1 | grep -q "Syntax OK"; then
+        systemctl reload apache2
+    else
+        echo -e "${RED}Apache config is invalid — NOT reloading.${NC}"
+        apache2ctl configtest 2>&1 | sed 's/^/    /'
+        echo -e "${YELLOW}Sites keep serving on the old config. Fix the above, then: systemctl reload apache2${NC}"
+    fi
 fi
 
 # ----------------------------------------------------------------

--- a/scripts/system/status.sh
+++ b/scripts/system/status.sh
@@ -14,13 +14,21 @@ fi
 
 PANEL_DB="/var/www/inetpanel/db/inetpanel.db"
 
-echo -e "${BOLD}═══════════════════════════════════════════════════${NC}"
+# Fall back to ASCII when the terminal is not UTF-8 — the Proxmox/noVNC console
+# is the common case, and there these render as a row of '?' characters.
+case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+    *UTF-8*|*utf-8*|*UTF8*|*utf8*) G_RULE='═'; G_SECT='▸'; G_DOT='●' ;;
+    *)                             G_RULE='='; G_SECT='>'; G_DOT='*' ;;
+esac
+RULE=$(printf '%51s' ''); RULE=${RULE// /$G_RULE}
+
+echo -e "${BOLD}${RULE}${NC}"
 echo -e "${BOLD}  iNetPanel Server Status${NC}"
-echo -e "${BOLD}═══════════════════════════════════════════════════${NC}"
+echo -e "${BOLD}${RULE}${NC}"
 echo ""
 
 # ── System ────────────────────────────────────────────────────────────────────
-echo -e "${CYAN}▸ System${NC}"
+echo -e "${CYAN}${G_SECT} System${NC}"
 echo -e "  Hostname:   ${BOLD}$(hostname)${NC}"
 echo -e "  OS:         $(lsb_release -ds 2>/dev/null || cat /etc/os-release 2>/dev/null | grep PRETTY_NAME | cut -d'"' -f2)"
 echo -e "  Kernel:     $(uname -r)"
@@ -39,7 +47,7 @@ echo -e "  Load:       ${BOLD}${LOAD}${NC} (${CORES} cores) [$LOAD_STATUS]"
 echo ""
 
 # ── Memory ────────────────────────────────────────────────────────────────────
-echo -e "${CYAN}▸ Memory${NC}"
+echo -e "${CYAN}${G_SECT} Memory${NC}"
 MEM_TOTAL=$(free -m | awk '/Mem:/ {print $2}')
 MEM_USED=$(free -m | awk '/Mem:/ {print $3}')
 MEM_PCT=$((MEM_USED * 100 / MEM_TOTAL))
@@ -58,7 +66,7 @@ fi
 echo ""
 
 # ── Disk ──────────────────────────────────────────────────────────────────────
-echo -e "${CYAN}▸ Disk${NC}"
+echo -e "${CYAN}${G_SECT} Disk${NC}"
 df -h / /home /backup 2>/dev/null | awk 'NR==1{next} !seen[$1]++ {
     pct=$5; gsub(/%/,"",pct);
     color="\033[1;32m"; if(pct>=80) color="\033[1;33m"; if(pct>=90) color="\033[1;31m";
@@ -67,7 +75,7 @@ df -h / /home /backup 2>/dev/null | awk 'NR==1{next} !seen[$1]++ {
 echo ""
 
 # ── Services ──────────────────────────────────────────────────────────────────
-echo -e "${CYAN}▸ Services${NC}"
+echo -e "${CYAN}${G_SECT} Services${NC}"
 
 PHP_VER=$(php -r 'echo PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION;' 2>/dev/null || echo "8.4")
 SERVICES="apache2 lighttpd php${PHP_VER}-fpm mariadb vsftpd cron fail2ban cloudflared wg-quick@wg0"
@@ -87,15 +95,15 @@ for svc in $SERVICES; do
 
     STATUS=$(systemctl is-active "$svc" 2>/dev/null)
     if [ "$STATUS" = "active" ]; then
-        printf "  %-20s ${GREEN}●${NC} running\n" "$DISPLAY_NAME"
+        printf "  %-20s ${GREEN}${G_DOT}${NC} running\n" "$DISPLAY_NAME"
     else
-        printf "  %-20s ${RED}●${NC} %s\n" "$DISPLAY_NAME" "$STATUS"
+        printf "  %-20s ${RED}${G_DOT}${NC} %s\n" "$DISPLAY_NAME" "$STATUS"
     fi
 done
 echo ""
 
 # ── SSL Certificates ─────────────────────────────────────────────────────────
-echo -e "${CYAN}▸ SSL Certificates${NC}"
+echo -e "${CYAN}${G_SECT} SSL Certificates${NC}"
 CERT_COUNT=0
 NEAREST_EXPIRY=""
 NEAREST_DOMAIN=""
@@ -119,7 +127,7 @@ fi
 echo ""
 
 # ── Backups ───────────────────────────────────────────────────────────────────
-echo -e "${CYAN}▸ Backups${NC}"
+echo -e "${CYAN}${G_SECT} Backups${NC}"
 BACKUP_DIR=$(sqlite3 "$PANEL_DB" "SELECT value FROM settings WHERE key='backup_destination'" 2>/dev/null)
 [ -z "$BACKUP_DIR" ] && BACKUP_DIR="/backup"
 if [ -d "$BACKUP_DIR" ]; then
@@ -139,7 +147,7 @@ fi
 echo ""
 
 # ── Accounts ──────────────────────────────────────────────────────────────────
-echo -e "${CYAN}▸ Accounts${NC}"
+echo -e "${CYAN}${G_SECT} Accounts${NC}"
 if [ -f "$PANEL_DB" ]; then
     USER_COUNT=$(sqlite3 "$PANEL_DB" "SELECT COUNT(*) FROM hosting_users" 2>/dev/null || echo 0)
     DOMAIN_COUNT=$(sqlite3 "$PANEL_DB" "SELECT COUNT(*) FROM domains" 2>/dev/null || echo 0)
@@ -149,14 +157,20 @@ fi
 
 # ── Panel Version ─────────────────────────────────────────────────────────────
 echo ""
-echo -e "${CYAN}▸ Panel${NC}"
-CURRENT_VER=$(grep "APP_VERSION" /var/www/inetpanel/TiCore/Version.php 2>/dev/null | grep -oP "'[^']+'" | tr -d "'")
+echo -e "${CYAN}${G_SECT} Panel${NC}"
+# Match only the constant declaration. A bare grep for APP_VERSION also hits the
+# doc comments and the self-update regex further down Version.php, which turned
+# CURRENT_VER into a multi-line blob and made every version comparison fail.
+CURRENT_VER=$(grep -oP "^\s*const APP_VERSION\s*=\s*'\K[^']+" /var/www/inetpanel/TiCore/Version.php 2>/dev/null | head -1)
 LATEST_VER=$(sqlite3 "$PANEL_DB" "SELECT value FROM settings WHERE key='panel_latest_ver'" 2>/dev/null)
 echo -e "  Version:    ${BOLD}${CURRENT_VER:-unknown}${NC}"
-if [ -n "$LATEST_VER" ] && [ "$LATEST_VER" != "$CURRENT_VER" ]; then
+# Only newer counts as an update — a stale panel_latest_ver must not read as one.
+if [ -n "$LATEST_VER" ] && [ -n "$CURRENT_VER" ] && \
+   [ "$(printf '%s\n%s\n' "$CURRENT_VER" "$LATEST_VER" | sort -V | tail -1)" = "$LATEST_VER" ] && \
+   [ "$LATEST_VER" != "$CURRENT_VER" ]; then
     echo -e "  Update:     ${YELLOW}v${LATEST_VER} available${NC}"
 else
     echo -e "  Update:     ${GREEN}up to date${NC}"
 fi
 echo ""
-echo -e "${BOLD}═══════════════════════════════════════════════════${NC}"
+echo -e "${BOLD}${RULE}${NC}"

--- a/scripts/system/update_ssh_port.sh
+++ b/scripts/system/update_ssh_port.sh
@@ -21,9 +21,23 @@ if [ -z "$NEW_PORT" ] || ! [[ "$NEW_PORT" =~ ^[0-9]+$ ]] || [ "$NEW_PORT" -lt 1 
 fi
 
 SSHD_CONF="/etc/ssh/sshd_config"
+DROPIN_DIR="/etc/ssh/sshd_config.d"
+DROPIN="${DROPIN_DIR}/99-inetpanel.conf"
 
-# Detect current SSH port
-OLD_PORT=$(grep -E '^Port ' "$SSHD_CONF" 2>/dev/null | awk '{print $2}')
+# Prefer a drop-in when the main config includes that directory. A Port line in
+# /etc/ssh/sshd_config does not survive an openssh-server upgrade: that file is
+# ucf-managed, and accepting the maintainer's version on the upgrade prompt
+# silently reverts the port — which locks you out on the next reconnect.
+USE_DROPIN=0
+if grep -qE '^[[:space:]]*Include[[:space:]]+/etc/ssh/sshd_config\.d/\*\.conf' "$SSHD_CONF" 2>/dev/null; then
+    USE_DROPIN=1
+    mkdir -p "$DROPIN_DIR"
+fi
+
+# Detect the port sshd is ACTUALLY using — the running config is authoritative,
+# and it may come from a drop-in rather than the main file.
+OLD_PORT=$(sshd -T 2>/dev/null | awk '/^port /{print $2; exit}')
+[ -z "$OLD_PORT" ] && OLD_PORT=$(grep -hE '^[[:space:]]*Port ' "$DROPIN" "$SSHD_CONF" 2>/dev/null | head -1 | awk '{print $2}')
 [ -z "$OLD_PORT" ] && OLD_PORT=22
 
 if [ "$OLD_PORT" = "$NEW_PORT" ]; then
@@ -33,13 +47,32 @@ fi
 
 echo -e "${BOLD}Changing SSH port: ${OLD_PORT} → ${NEW_PORT}${NC}"
 
-# 1. Update sshd_config
-if grep -qE '^Port ' "$SSHD_CONF"; then
-    sed -i "s/^Port .*/Port ${NEW_PORT}/" "$SSHD_CONF"
+# 1. Update sshd config (keep a copy of everything we touch, for the revert path)
+HAD_DROPIN=0
+cp "$SSHD_CONF" "${SSHD_CONF}.inetp-bak"
+[ -f "$DROPIN" ] && { HAD_DROPIN=1; cp "$DROPIN" "${DROPIN}.inetp-bak"; }
+
+if [ "$USE_DROPIN" -eq 1 ]; then
+    cat > "$DROPIN" << DROPIN_EOF
+# Managed by iNetPanel — do not edit by hand.
+# Kept here instead of /etc/ssh/sshd_config so an openssh-server upgrade cannot
+# revert the port. Change it from the panel's Firewall page, or with:
+#   sudo /root/scripts/update_ssh_port.sh --port <n>
+Port ${NEW_PORT}
+DROPIN_EOF
+    chmod 644 "$DROPIN"
+    # One source of truth: neutralise any Port left in the main file. (Port is not
+    # a valid keyword inside a Match block, so this cannot hit a conditional one.)
+    sed -i 's/^[[:space:]]*Port /#Port /' "$SSHD_CONF"
+    echo -e "  ${GREEN}${DROPIN} updated${NC}"
 else
-    echo "Port ${NEW_PORT}" >> "$SSHD_CONF"
+    if grep -qE '^Port ' "$SSHD_CONF"; then
+        sed -i "s/^Port .*/Port ${NEW_PORT}/" "$SSHD_CONF"
+    else
+        echo "Port ${NEW_PORT}" >> "$SSHD_CONF"
+    fi
+    echo -e "  ${GREEN}sshd_config updated${NC}"
 fi
-echo -e "  ${GREEN}sshd_config updated${NC}"
 
 # 2. Update firewalld (if running)
 if command -v firewall-cmd &>/dev/null && firewall-cmd --state &>/dev/null; then
@@ -67,12 +100,25 @@ if [ -f "$JAIL_LOCAL" ]; then
 fi
 
 # 4. Validate config and restart SSH
-if sshd -t 2>/dev/null; then
-    systemctl restart sshd 2>/dev/null
-    echo -e "  ${GREEN}SSH restarted on port ${NEW_PORT}${NC}"
+if sshd -t 2>/dev/null && systemctl restart sshd 2>/dev/null; then
+    # Confirm sshd really came back on the new port before declaring success —
+    # reporting a port change that did not take effect is how people get locked out.
+    ACTUAL=$(sshd -T 2>/dev/null | awk '/^port /{print $2; exit}')
+    if [ "$ACTUAL" = "$NEW_PORT" ]; then
+        rm -f "${SSHD_CONF}.inetp-bak" "${DROPIN}.inetp-bak"
+        echo -e "  ${GREEN}SSH restarted on port ${NEW_PORT}${NC}"
+    else
+        echo -e "  ${YELLOW}Config written, but sshd reports port '${ACTUAL:-unknown}'.${NC}"
+        echo -e "  ${YELLOW}Keep your current session open and verify before reconnecting.${NC}"
+    fi
 else
-    echo -e "  ${RED}sshd config test failed! Reverting to port ${OLD_PORT}...${NC}"
-    sed -i "s/^Port .*/Port ${OLD_PORT}/" "$SSHD_CONF"
+    echo -e "  ${RED}sshd config test or restart failed! Reverting to port ${OLD_PORT}...${NC}"
+    cp "${SSHD_CONF}.inetp-bak" "$SSHD_CONF"
+    if [ "$USE_DROPIN" -eq 1 ]; then
+        if [ "$HAD_DROPIN" -eq 1 ]; then mv "${DROPIN}.inetp-bak" "$DROPIN"; else rm -f "$DROPIN"; fi
+    fi
+    rm -f "${SSHD_CONF}.inetp-bak"
+    systemctl restart sshd 2>/dev/null
     exit 1
 fi
 


### PR DESCRIPTION
Fixes the root cause behind #17 (all sites 502 after an `apt upgrade`) plus everything else that turned up while reproducing it.

## The outage chain

A domain deleted at some earlier point left its vhost in `sites-enabled` pointing at a `DocumentRoot` and log directory that no longer existed. Apache kept serving on its already-loaded config, so nothing looked wrong — until `apt upgrade` restarted it. A missing **log directory** is fatal at startup, Apache refused to come up, and cloudflared had no origin to reach. Hence 502 on every site at once rather than one.

`delete_account.sh` enumerated a user's domains by globbing `/home/<user>/*/www`. With the home dir already gone, the glob found nothing, `remove_domain.sh` never ran, and the vhost was orphaned.

## Changes

| commit | fix |
|---|---|
| `4742bb8` | `delete_account.sh` — enumerate domains from the filesystem, the panel DB, **and** vhost ownership |
| `cc0b564` | `remove_domain.sh` / `add_domain.sh` — `configtest` before reload; never escalate a failed reload to a restart; stop overwriting a live site's `index.php` on recreate |
| `7b6046b` | new `inetp rebuild_vhosts` — regenerate missing vhosts from the DB, report/disable orphans |
| `4b31edd` | `dns_check.sh` — accept a bare domain |
| `9d18224` | `status.sh` — version parse, `sort -V` update comparison, ASCII fallback for non-UTF-8 consoles |
| `e7b09c0` | `update_ssh_port.sh` — port lives in `sshd_config.d/99-inetpanel.conf`, verify it took effect, full revert on failure |

The `reload || restart` fallback deserves calling out: a reload that fails is harmless (the good config keeps serving), but the restart that followed it took the whole box down. That ordering turned a single bad vhost into a total outage.

## Verification

Run against a live 1.24.4 box with 35 domains:

- all 8 scripts pass `bash -n`
- `status.sh` reproduced the exact garbage block from #17, and the fix prints `Version: 1.24.4 / Update: up to date`
- `status.sh` renders correctly under both `LANG=C.UTF-8` and `LC_ALL=C`
- `dns_check.sh` accepts `example.com`, `--domain example.org`, and `--verbose example.net`
- `rebuild_vhosts --check` dry-ran clean: 35 skipped, 0 missing, 0 orphaned
- the vhost template `rebuild_vhosts` generates reproduces an existing vhost byte for byte (port and FPM socket path both match)

**`update_ssh_port.sh` is the exception** — it rewrites sshd config, so I did not exercise it on a live box. It wants a test where a lockout doesn't matter.

## Notes

- **No version bump.** The `post-commit` hook from `install-hooks.sh` wasn't installed in this clone, so `Version.php` is untouched — the release commit can own that.
- **CRLF left alone.** `TiCore/*.php`, `src/*.php` and `themes/default/*.php` still have CRLF committed while `.gitattributes` asks for LF, so they show as modified on a fresh clone. Unrelated to this work and a big diff, so I left it. Worth a `git add --renormalize .` on its own commit.
